### PR TITLE
Remove dependency on local jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'com.github.johnrengelman.shadow' version '6.1.0'
     id 'java'
 }
 
@@ -16,7 +16,6 @@ shadowJar {
 
 repositories {
     mavenCentral()
-    mavenLocal()
 
     maven {
         name = 'spigotmc-repo'
@@ -34,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.spigotmc:spigot:1.16.1-R0.1-SNAPSHOT'
+    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.16.1-R0.1-SNAPSHOT', changing: true
     compileOnly 'me.clip:placeholderapi:2.11.4'
     implementation 'com.sun.mail:javax.mail:1.6.2'
     implementation 'javax.activation:activation:1.1.1'

--- a/src/main/java/me/lagbug/emailer/spigot/common/utils/util/CommonUtils.java
+++ b/src/main/java/me/lagbug/emailer/spigot/common/utils/util/CommonUtils.java
@@ -13,7 +13,6 @@ import java.util.Random;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.spigotmc.SpigotConfig;
 
 public class CommonUtils {
 
@@ -119,7 +118,20 @@ public class CommonUtils {
 	}
 
 	public static boolean isBungee() {
-		return SpigotConfig.bungee && (!(Bukkit.getServer().getOnlineMode()));
+		boolean bungee = false;
+		
+		try {
+            Class<?> spigotConfigClass = Class.forName("org.spigotmc.SpigotConfig");
+            Field bungeeField = spigotConfigClass.getDeclaredField("bungee");
+            bungeeField.setAccessible(true);
+            bungee = bungeeField.getBoolean(null);
+
+        } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
+        	System.err.println("Reflection failed for isBungee method in CommonUtils (me.lagbug).");
+            e.printStackTrace();
+        }
+		
+		return bungee && (!(Bukkit.getServer().getOnlineMode()));
 	}
 
 	public static void log(String... text) {


### PR DESCRIPTION
I made this PR to make it easier to compile the plugin.

No longer using spigot jar. Instead now using spigot-api jar. And since the spigot-api jar does not have access to the SpigotConfig class, I have replaced the method isBungee with reflection.

I did not test the shadowed jar. Testing is needed.

I changed the version of shadow also so it would compile on my older Gradle version.